### PR TITLE
python string concatenation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ required_dirs = [
     'data/subscribers'
 ]
 required_files = [
-    'data/subscribers/spartakiada24.txt'
-    'data/subscribers/spartakiada.txt'
+    'data/subscribers/spartakiada24.txt',
+    'data/subscribers/spartakiada.txt',
     'data/subscribers/ignored.txt'
 ]
 


### PR DESCRIPTION
Multiple adjacent string or bytes literals (delimited by whitespace), possibly using different quoting conventions, are allowed, and their meaning is the same as their concatenation. Thus, "hello" 'world' is equivalent to "helloworld". This feature can be used to reduce the number of backslashes needed, to split long strings conveniently across long lines, or even to add comments to parts of strings, for example:
```
re.compile("[A-Za-z_]"       # letter or underscore
           "[A-Za-z0-9_]*"   # letter, digit or underscore
          )
```
Note that this feature is defined at the syntactical level, but implemented at compile time. The ‘+’ operator must be used to concatenate string expressions at run time. Also note that literal concatenation can use different quoting styles for each component (even mixing raw strings and triple quoted strings), and formatted string literals may be concatenated with plain string literals.

[src](https://docs.python.org/3.12/reference/lexical_analysis.html#string-literal-concatenation)